### PR TITLE
Removing plugin requirements from .uproject files

### DIFF
--- a/SteamVR_1_6/SteamVR_1_6.uproject
+++ b/SteamVR_1_6/SteamVR_1_6.uproject
@@ -2,11 +2,5 @@
 	"FileVersion": 3,
 	"EngineAssociation": "4.11",
 	"Category": "",
-	"Description": "",
-	"Plugins": [
-		{
-			"Name": "Substance",
-			"Enabled": true
-		}
-	]
+	"Description": ""
 }

--- a/SteamVR_1_7/SteamVR_1_7.uproject
+++ b/SteamVR_1_7/SteamVR_1_7.uproject
@@ -2,11 +2,5 @@
 	"FileVersion": 3,
 	"EngineAssociation": "4.11",
 	"Category": "",
-	"Description": "",
-	"Plugins": [
-		{
-			"Name": "Substance",
-			"Enabled": true
-		}
-	]
+	"Description": ""
 }

--- a/SteamVR_1_8/SteamVR_1_8.uproject
+++ b/SteamVR_1_8/SteamVR_1_8.uproject
@@ -2,11 +2,5 @@
 	"FileVersion": 3,
 	"EngineAssociation": "4.11",
 	"Category": "",
-	"Description": "",
-	"Plugins": [
-		{
-			"Name": "Substance",
-			"Enabled": true
-		}
-	]
+	"Description": ""
 }

--- a/SteamVR_1_9/SteamVR_1_9.uproject
+++ b/SteamVR_1_9/SteamVR_1_9.uproject
@@ -2,16 +2,5 @@
 	"FileVersion": 3,
 	"EngineAssociation": "4.11",
 	"Category": "",
-	"Description": "",
-	"Plugins": [
-		{
-			"Name": "Substance",
-			"Enabled": true
-		},
-		{
-			"Name": "GameAnalytics",
-			"Enabled": true,
-			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/offers/d070c3fab7b74c08bab3a89c9cbf4490"
-		}
-	]
+	"Description": ""
 }


### PR DESCRIPTION
Re: https://github.com/ProteusVR/SteamVR-Template/issues/1

A simple PR. I've just removed the lines from the `.uproject` files which ask for the user to have `Substance` and `GameAnalytics` installed. Doesn't impact functionality at all aside from lessening what you need to launch.